### PR TITLE
RT119878 patch applied for pod issues

### DIFF
--- a/lib/HTTP/DAV.pm
+++ b/lib/HTTP/DAV.pm
@@ -1773,7 +1773,7 @@ The return value is always 1 or 0 indicating success or failure.
 
 See L<get()> for a description of what the optional callback parameter does.
 
-You can also pass a C<-headers> argument. That allows to specify custom HTTP headers. It can be either a hashref with header names and values, or a L<HTTP::Headers> object.
+You can also pass a C<-headers> argument. That allows one to specify custom HTTP headers. It can be either a hashref with header names and values, or a L<HTTP::Headers> object.
 
 B<put examples:>
 
@@ -2045,7 +2045,7 @@ or the README file in this library.
 
 You'll want to also read:
 
-=over *
+=over
 
 =item C<HTTP::DAV::Response>
 
@@ -2057,7 +2057,7 @@ You'll want to also read:
 
 and maybe if you're more inquisitive:
 
-=over *
+=over
 
 =item C<LWP::UserAgent>
 

--- a/lib/HTTP/DAV/Lock.pm
+++ b/lib/HTTP/DAV/Lock.pm
@@ -34,7 +34,12 @@ sub _init {
 }
 
 ###########################################################################
-# ACCESSOR METHODS
+
+=head1 ACCESSOR METHODS
+
+=over
+
+=cut
 
 # GET
 sub get_owner { $_[0]->{_owner}; }

--- a/lib/HTTP/DAV/Resource.pm
+++ b/lib/HTTP/DAV/Resource.pm
@@ -1925,5 +1925,7 @@ $resource->set_parent_resourcelist( $resourcelist )
 
 Sets the parent resource list (ask the question, which collection am I a member of?). See L<HTTP::DAV::ResourceList>.
 
+=back
+
 =cut
 

--- a/lib/HTTP/DAV/Response.pm
+++ b/lib/HTTP/DAV/Response.pm
@@ -189,7 +189,7 @@ Instances of this class are usually created by a C<HTTP::DAV::Resource> object a
 
 HTTP::DAV::Response was created to handle two extra functions that normal HTTP Responses don't require:
 
- - WebDAV reponses have 6 extra error codes: 102, 207, 422, 423, 424 and 507. Older versions of the LWP's C<HTTP::Status> class did not have these extra codes. These were added.
+ - WebDAV responses have 6 extra error codes: 102, 207, 422, 423, 424 and 507. Older versions of the LWP's C<HTTP::Status> class did not have these extra codes. These were added.
 
  - WebDAV responses can actually contain more than one response (and often DO contain more than one) in the form of a "Multistatus". These multistatus responses come in the form of an XML document. HTTP::DAV::Response can accurately parse these XML responses and emulate the normal of the C<HTTP::Response>.
 
@@ -312,6 +312,8 @@ e.g. $messages eq "Forbidden\nLocked";
 e.g. @messages eq ["Forbidden", "Locked"];
 
 This routine is a variant on the standard C<HTTP::Response> C<message()>. 
+
+=back
 
 =cut
 


### PR DESCRIPTION
 ```
 Subject:[PATCH] fix a number of pod issues
 Date:Mon, 16 Jan 2017 21:46:15 +0100
 To:bug-http-dav [...] rt.cpan.org
 From:Florian Schlichting <fsfs [...] debian.org>
 Download (untitled) / with headers
 text/plain 453b

 In Debian we are currently applying the following patch to HTTP-DAV.
 We thought you might be interested in it too.

 Description: fix a number of pod issues that lintian warns about
 Author: Florian Schlichting <fsfs@debian.org>

 The patch is tracked in our Git repository at
 https://anonscm.debian.org/cgit/pkg-perl/packages/libhttp-dav-perl.git/plain/debian/patches/pod-issues.patch

 Thanks for considering,
   Florian Schlichting,
   Debian Perl Group
```

NOTE: Repo above has moved to
https://salsa.debian.org/perl-team/modules/packages/libhttp-dav-perl

I am working on some other POD cleanup to get `podchecker` to have no warnings for any files. I will submit another pull when I have completed them.
