### PR TITLE
Use a lookup hash to improve HTTP::DAV::ResourceList's performance

### DIFF
--- a/lib/HTTP/DAV/Utils.pm
+++ b/lib/HTTP/DAV/Utils.pm
@@ -215,6 +215,13 @@ sub make_uri {
     return $uri;
 }
 
+sub make_uri_canonical {
+    $_ = make_uri(shift);
+    s{/$}{};
+    s{(%[0-9a-fA-F][0-9a-fA-F])}{lc $1}eg;
+    return $_;
+}
+
 sub make_trail_slash {
     my ($uri) = @_;
     $uri =~ s{/*$}{}g;
@@ -225,13 +232,7 @@ sub make_trail_slash {
 sub compare_uris {
     my ($uri1,$uri2) = @_;
 
-    for ($uri1, $uri2) {
-        $_ = make_uri($_);
-        s{/$}{};
-        s{(%[0-9a-fA-F][0-9a-fA-F])}{lc $1}eg;
-	}
-
-    return $uri1 eq $uri2;
+    return make_uri_canonical($uri1) eq make_uri_canonical($uri2);
 }
 
 # This subroutine takes a URI and gets the last portion 


### PR DESCRIPTION
Before this, adding an element to a ResourceList involved scanning
the entire list each time, calling compare_uris twice for each element.

This approach uses a lookup table of pre-stripped resource URIs mapped
to array indexes. This preserves the original order of elements while
making the lookup O(1) rather than O(very costly N). A faster lookup
results in faster removal, and thus faster adding too.

For big-ish resource lists (1000 elements) this cuts down the time it
takes to create the ResourceList by 95% (from ~30 seconds to ~1.5).